### PR TITLE
Updating  README package reference with @infinity-interactive scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The interactive(!) demo page lives at [https://yanick.github.io/jsonschematic/](
 
 From a global install:
 
-    $ npm install -g jsonschematic
+    $ npm install -g @infinity-interactive/jsonschematic
     $ jsonschematic --schema_dir path/to/schemas
 
 From the repo:


### PR DESCRIPTION
This project doesn't seem to be maintained, but I went to try it out and `jsonschematic` isn't a published npm package, so I figured I'd update the readme with the proper scope.